### PR TITLE
Update CookieStorage.php

### DIFF
--- a/src/Bundle/Storage/CookieStorage.php
+++ b/src/Bundle/Storage/CookieStorage.php
@@ -17,8 +17,8 @@ use Sylius\Component\Resource\Storage\StorageInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\ParameterBag;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 final class CookieStorage implements StorageInterface, EventSubscriberInterface
@@ -46,7 +46,7 @@ final class CookieStorage implements StorageInterface, EventSubscriberInterface
         ];
     }
 
-    public function onKernelRequest(GetResponseEvent $event): void
+    public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMasterRequest()) {
             return;
@@ -56,7 +56,7 @@ final class CookieStorage implements StorageInterface, EventSubscriberInterface
         $this->responseCookies = new ParameterBag();
     }
 
-    public function onKernelResponse(FilterResponseEvent $event): void
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if (!$event->isMasterRequest()) {
             return;


### PR DESCRIPTION
- use Symfony\Component\HttpKernel\Event\ResponseEvent instead of Symfony\Component\HttpKernel\Event\FilterResponseEvent
- use Symfony\Component\HttpKernel\Event\RequestEvent instead of Symfony\Component\HttpKernel\Event\GetResponseEvent;	

as 
- onKernelRequest requires RequestEvent
- onKernelResponse requires ResponseEvent